### PR TITLE
Feature/adapt for restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 docker-compose.override.yml
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -81,16 +81,13 @@ State of a particular vehicle at a particular time. Some fields may be null if n
 
 | Field Name | Type | Description |
 | --- | --- | --- |
-| `vid` | `String` | ID of this vehicle. |
-| `did` | `String` | ID of the direction the vehicle reported it was going. |
-| `lat` | `Float` | Reported latitude of vehicle. |
-| `lon` | `Float` | Reported longitude of vehicle. |
-| `heading` | `Float` | Reported heading of vehicle in degrees. |
+| `vehicleID` | `String` | ID of this vehicle. |
+| `direction` | `String` | ID of the direction the vehicle reported it was going. |
+| `latitude` | `Float` | Reported latitude of vehicle. |
+| `longitude` | `Float` | Reported longitude of vehicle. |
+| `bearing` | `Float` | Reported heading of vehicle in degrees. |
 | `secsSinceReport` | `Int` | Number of seconds old this observation was when it was retrieved (at `timestamp` of `RouteState`). |
-| `numCars` | `Int` | Number of cars in this vehicle. |
-| `stopIndex` | `Int` | The index of the current stop in the sequence (GTFS-realtime providers only) |
-| `status` | `Int` | 0 if the vehicle is about to arrive at the stop referred to by `stopIndex`, 1 if the vehicle is stopped at this stop, 2 if the vehicle is in transit to this stop (GTFS-realtime providers only) |
-| `tripId` | `String` | ID of the trip the vehicle reported it was running (GTFS-realtime providers only) |
+| `tripID` | `String` | ID of the trip the vehicle reported it was running (GTFS-realtime providers only) |
 
 ## Sample Query
 
@@ -98,7 +95,10 @@ Once you run it, go to http://localhost:4000/graphql in your browser and run thi
 
 ```
 query {
-  state(agencyId: "muni", startTime: 1572105600, endTime: 1572112800, routes: ["14", "19", "49"]) {
+  state(agencyId: "trimet"
+    , startTime: 1642867201
+    , endTime: 1642867500
+    , routes: ["100"]) {
     agencyId
     startTime
     routes {
@@ -106,10 +106,14 @@ query {
       states {
         timestamp
         vehicles {
-          vid
-          lat
-          lon
-          heading
+          vehicleID
+          tripID
+          latitude
+          longitude
+          direction
+          bearing
+          time
+          secsSinceReport
         }
       }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,7 @@ services:
       - "4000:4000"
     volumes:
       - ./src:/usr/src/app/src
+    environment:
+      TRYNAPI_S3_BUCKET: "opentransit-pdx"
+      AWS_ACCESS_KEY_ID: ""
+      AWS_SECRET_ACCESS_KEY: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,3 @@ services:
       - ./src:/usr/src/app/src
     environment:
       TRYNAPI_S3_BUCKET: "opentransit-pdx"
-      AWS_ACCESS_KEY_ID: ""
-      AWS_SECRET_ACCESS_KEY: ""

--- a/examples/marin-query.graphql
+++ b/examples/marin-query.graphql
@@ -1,7 +1,10 @@
-# replace "marin" with "muni" to use that as the agency
+# replace "trimet" with your agency
 
 query {
-  state(agencyId: "marin", startTime: 1572127400, endTime: 1572127900) {
+  state(agencyId: "trimet"
+    , startTime: 1642867201
+    , endTime: 1642867500
+    , routes: ["100"]) {
     agencyId
     startTime
     routes {
@@ -9,10 +12,14 @@ query {
       states {
         timestamp
         vehicles {
-          vid
-          lat
-          lon
-          heading
+          vehicleID
+          tripID
+          latitude
+          longitude
+          direction
+          bearing
+          time
+          secsSinceReport
         }
       }
     }

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -46,11 +46,14 @@ const resolvers = {
 
                         // console.log(vehicle)
                         const routeId = vehicle.routeNumber;
-                        const vtime = queryTime;
+                        const vtime = Math.floor(Number(queryTime)/1000);
                         const vehicleID = vehicle.vehicleID;
                         const tempVehicleTime = vehicleID+'_'+vtime;
+                        const vehicleTIme = Math.floor(Number(vehicle.time)/1000);
 
-                        const secsSinceReport = Math.floor((Number(vtime)-Number(vehicle.time))/1000);
+                        const secsSinceReport = (vtime-vehicleTIme);
+
+                        vehicle.time = vehicleTIme;
 
                         vehicle.secsSinceReport = secsSinceReport;
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -18,65 +18,71 @@ const resolvers = {
 
             let { startTime, endTime } = params;
 
-            const vehicles = await s3Helper.getVehicles(agencyId, startTime, endTime);
+            console.log(agencyId, routes)
+
+            const resultSets = await s3Helper.getVehicles(agencyId, startTime, endTime);
+
 
             const vehiclesByTripByTime = {};
             const vehiclesByRouteByTime = {};
+            const UniqueVehicleTimeKeys = {};
 
             // group the vehicles by route, and then by time
+            // below are fields in the vehicle api response
+            // 'serviceDate', 'latitude', 'nextStopSeq', 'type', 'blockID',
+//         'signMessageLong', 'lastLocID', 'nextLocID', 'locationInScheduleDay',
+//         'longitude', 'direction', 'routeNumber', 'bearing', 'garage', 'tripID',
+//         'delay', 'lastStopSeq', 'vehicleID', 'time'
 
-            vehicles.forEach(vehicle => {
-                const routeId = vehicle.rid;
-                const vtime = vehicle.timestamp;
+            
 
-                if (!vehiclesByRouteByTime[routeId]) {
-                    vehiclesByRouteByTime[routeId] = {};
-                }
-                if (!vehiclesByRouteByTime[routeId][vtime]) {
-                    vehiclesByRouteByTime[routeId][vtime] = [];
-                }
+                resultSets.forEach(results => {
 
-                // check for multiple vehicles with the same tripId, assume to be multiple-car trains if close to each other
-                const tripId = vehicle.tripId;
-                if (tripId) {
-                    if (!vehiclesByTripByTime[tripId]) {
-                        vehiclesByTripByTime[tripId] = {};
-                    }
-                    const prevVehicle = vehiclesByTripByTime[tripId][vtime];
-                    if (!prevVehicle) {
-                        vehiclesByTripByTime[tripId][vtime] = vehicle;
-                    } else if (Math.abs(prevVehicle.lat - vehicle.lat) < 0.001 && Math.abs(prevVehicle.lon - vehicle.lon) < 0.001) {
-                        // 0.001 degrees latitude = 111m, 0.001 degrees longitude typically between between ~50m and 111m
-                        prevVehicle.numCars = (prevVehicle.numCars || 1) + 1;
-                        if (prevVehicle.vid > vehicle.vid) {
-                            prevVehicle.vid = vehicle.vid;
+                    const queryTime = results.resultSet.queryTime;
+
+                    if (!(results.resultSet['vehicle']===undefined)) {
+
+                    results.resultSet.vehicle.forEach(vehicle => {
+
+                        // console.log(vehicle)
+                        const routeId = vehicle.routeNumber;
+                        const vtime = queryTime;
+                        const vehicleID = vehicle.vehicleID;
+                        const tempVehicleTime = vehicleID+'_'+vtime;
+
+                        const secsSinceReport = Math.floor((Number(vtime)-Number(vehicle.time))/1000);
+
+                        vehicle.secsSinceReport = secsSinceReport;
+
+                        if (!vehiclesByRouteByTime[routeId]) {
+                            vehiclesByRouteByTime[routeId] = {};
                         }
-                        return;
-                    }
+                        if (!vehiclesByRouteByTime[routeId][vtime]) {
+                            vehiclesByRouteByTime[routeId][vtime] = [];
+                        }
+
+                        if (!UniqueVehicleTimeKeys[tempVehicleTime]) {
+                            vehiclesByRouteByTime[tempVehicleTime] = [];
+                            vehiclesByRouteByTime[routeId][vtime].push(vehicle);
+                        }
+
+                    });
+
+                    
+
+
+                    
+                    
+                    
                 }
-
-                vehiclesByRouteByTime[routeId][vtime].push(vehicle);
+                
             });
-
-            // remove duplicate Muni Metro vehicles
-            if (agencyId === 'muni') {
-                const affectedRouteIDs = ['KT', 'L', 'M', 'N', 'J'];
-                affectedRouteIDs.forEach(routeID => {
-                    if (debug) {
-                        console.log(routeID);
-                    }
-                    if (vehiclesByRouteByTime[routeID]) {
-                        vehiclesByRouteByTime[routeID] = removeMuniMetroDuplicates(
-                            vehiclesByRouteByTime[routeID],
-                        );
-                    }
-                });
-            }
 
             // get all the routes
             const routeIDs = routes ?
                 _.intersection(routes, Object.keys(vehiclesByRouteByTime)) :
                 Object.keys(vehiclesByRouteByTime);
+
 
             return {
                 agencyId,
@@ -85,6 +91,7 @@ const resolvers = {
                 endTime,
                 vehiclesByRouteByTime
             };
+        
         },
     },
 
@@ -110,18 +117,23 @@ const resolvers = {
         }
     },
 
+            // list all available fields
+            // 'serviceDate', 'latitude', 'nextStopSeq', 'type', 'blockID',
+//         'signMessageLong', 'lastLocID', 'nextLocID', 'locationInScheduleDay',
+//         'longitude', 'direction', 'routeNumber', 'bearing', 'garage', 'tripID',
+//         'delay', 'lastStopSeq', 'vehicleID', 'time'
+
     VehicleState: {
-        vid: vehicle => vehicle.vid,
-        did: vehicle => vehicle.did,
-        lat: vehicle => vehicle.lat,
-        lon: vehicle => vehicle.lon,
-        heading: vehicle => vehicle.heading,
+        vehicleID: vehicle => vehicle.vehicleID,
+        direction: vehicle => vehicle.direction,
+        latitude: vehicle => vehicle.latitude,
+        longitude: vehicle => vehicle.longitude,
+        bearing: vehicle => vehicle.bearing,
+        tripID: vehicle => vehicle.tripID,
+        nextStopSeq: vehicle => vehicle.nextStopSeq,
+        lastStopSeq: vehicle => vehicle.lastStopSeq,
+        time: vehicle => vehicle.time,
         secsSinceReport: vehicle => vehicle.secsSinceReport,
-        numCars: vehicle => vehicle.numCars,
-        tripId: vehicle => vehicle.tripId,
-        stopId: vehicle => vehicle.stopId,
-        stopIndex: vehicle => vehicle.stopIndex,
-        status: vehicle => vehicle.status,
     }
 };
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,17 +1,16 @@
 scalar BigInt
 
 type VehicleState {
-    vid: String
-    did: String
-    lat: Float
-    lon: Float
-    heading: Int
-    secsSinceReport: Int
-    numCars: Int
-    tripId: String
-    stopIndex: Int
-    stopId: String
-    status: Int
+    vehicleID: String
+    direction: String
+    latitude: Float
+    longitude: Float
+    bearing: Int
+    tripID: String
+    nextStopSeq: Int
+    lastStopSeq: Int
+    time: BigInt
+    secsSinceReport: BigInt
 }
 
 type RouteState {


### PR DESCRIPTION
Updating TrynAPI schema, resolver, and s3helper code to align with Trimet API and new S3 bucket configuration. 

## Main Updates
- field names are different (for instance, new "vehicleID" vs. previous "vid")
- some field names are not available (for instance, new "heading" vs. previous "bearing")
- old s3 bucket used to store data by the minute `${agencyId}/${year}/${month}/${day}/${hour}/${minute}/`
- new s3 bucket stores data by the hour `${agencyId}/${year}/${month}/${day}/${hour}/`
- functions have been adapted to the modified s3 setup but there is room for improvement. It works now but I would suggest an issue for future improvement. There are inefficiencies in the way it searches the bucket for new files within a timeframe.