### PR TITLE
rename tryn-api to opentransit-state-api; update orion references to opentransit-collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 CMD [ "npm", "start" ]
 
 # Build
-# docker build -t tryn-api .
+# docker build -t opentransit-state-api .
 
 # Run
-# docker run -p 4000:4000 tryn-api:latest
+# docker run -p 4000:4000 opentransit-state-api:latest

--- a/README.md
+++ b/README.md
@@ -1,30 +1,26 @@
-# tryn-api
+# OpenTransit State API
 
 API for historical transit vehicle location data.
 
-tryn-api provides a GraphQL API for the data previously stored in S3 by Orion (https://github.com/trynmaps/orion).
+OpenTransit State API provides a GraphQL API for the data previously stored in S3 by OpenTransit Collector (https://github.com/codeforpdx/opentransit-collector).
 
 ## Getting Started
 
-See our welcome doc for contribution and deployment guidelines.
-https://bit.ly/opentransit-onboarding
-
 1. Clone this repo.
 
-2. Create a docker-compose.override.yml file that sets the environment variable TRYNAPI_S3_BUCKET to the name of the S3 bucket where data was stored by Orion,
-and provides AWS credentials with read access to that bucket. tryn-api reads data from S3 using the AWS credentials from the default locations,
+2. Create a docker-compose.override.yml file that sets the environment variable OPENTRANSIT_S3_BUCKET to the name of the S3 bucket where data was stored by OpenTransit Collector, and provides AWS credentials with read access to that bucket. The OpenTransit State API reads data from S3 using the AWS credentials from the default locations,
 e.g. a credentials file located within the Docker container at /root/.aws/credentials (using the default profile or a profile named by AWS_PROFILE),
 or using the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. For example:
 
 ```
 version: "3.7"
 services:
-  tryn-api-dev:
+  state-api-dev:
     volumes:
       - ../.aws:/root/.aws
     environment:
       AWS_PROFILE: "default"
-      TRYNAPI_S3_BUCKET: "my-opentransit-bucket"
+      OPENTRANSIT_S3_BUCKET: "my-opentransit-bucket"
 ```
 
 2. Run `docker-compose up`
@@ -45,7 +41,7 @@ The root query object for the API.
 
 | Parameter Name | Type | Description |
 | --- | --- | --- |
-| `agency` | `String!` | ID of the agency. The agency ID should be the same ID used in the configuration for Orion. |
+| `agency` | `String!` | ID of the agency. The agency ID should be the same ID used in the configuration for OpenTransit Collector. |
 | `startTime` | `BigInt!` | Start timestamp in seconds since the Unix epoch. |
 | `endTime` | `BigInt!` | End timestamp in seconds since the Unix epoch , exclusive. |
 | `routes` | `[String!]` | List of route IDs to return vehicle data. |
@@ -54,7 +50,7 @@ The root query object for the API.
 
 | Field Name | Type | Description |
 | --- | --- | --- |
-| `agencyId` | `String` | ID of the agency. The agency ID should be the same ID used in the configuration for Orion. |
+| `agencyId` | `String` | ID of the agency. The agency ID should be the same ID used in the configuration for OpenTransit Collector. |
 | `startTime` | `BigInt` | Start timestamp in seconds since the Unix epoch. |
 | `endTime` | `BigInt` | End timestamp in seconds since the Unix epoch, exclusive. |
 | `routes` | [`[RouteHistory]`](#routehistory) | Array of historical state for each route. |
@@ -117,4 +113,4 @@ query {
 }
 ```
 
-Substitute startTime and endTime with epoch timestamps (in seconds) corresponding to when Orion was actually running.
+Substitute startTime and endTime with epoch timestamps (in seconds) corresponding to when OpenTransit Collector was actually running.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,16 +1,16 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/tryn-api:$REVISION_ID', '.' ]
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/opentransit-state-api:$REVISION_ID', '.' ]
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'push', 'gcr.io/$PROJECT_ID/tryn-api:$REVISION_ID' ]
+  args: [ 'push', 'gcr.io/$PROJECT_ID/opentransit-state-api:$REVISION_ID' ]
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'tag', 'gcr.io/$PROJECT_ID/tryn-api:$REVISION_ID', 'gcr.io/$PROJECT_ID/tryn-api:latest' ]
+  args: [ 'tag', 'gcr.io/$PROJECT_ID/opentransit-state-api:$REVISION_ID', 'gcr.io/$PROJECT_ID/opentransit-state-api:latest' ]
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'push', 'gcr.io/$PROJECT_ID/tryn-api:latest' ]
+  args: [ 'push', 'gcr.io/$PROJECT_ID/opentransit-state-api:latest' ]
 - name: 'gcr.io/cloud-builders/kubectl'
-  args: [ 'set', 'image', 'deployment/tryn-api', 'tryn-api=gcr.io/$PROJECT_ID/tryn-api:$REVISION_ID' ]
+  args: [ 'set', 'image', 'deployment/opentransit-state-api', 'opentransit-state-api=gcr.io/$PROJECT_ID/opentransit-state-api:$REVISION_ID' ]
   env:
   - 'CLOUDSDK_COMPUTE_ZONE=${_COMPUTE_ZONE}'
   - 'CLOUDSDK_CONTAINER_CLUSTER=${_CONTAINER_CLUSTER}'
 images:
-- 'gcr.io/$PROJECT_ID/tryn-api:$REVISION_ID'
+- 'gcr.io/$PROJECT_ID/opentransit-state-api:$REVISION_ID'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
-  tryn-api-dev:
-    container_name: tryn-api-dev
+  state-api-dev:
+    container_name: state-api-dev
     build:
       dockerfile: Dockerfile
       context: .

--- a/kubernetes/state-api-deployment.example.yaml
+++ b/kubernetes/state-api-deployment.example.yaml
@@ -2,12 +2,12 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    run: tryn-api
-  name: tryn-api
+    run: opentransit-state-api
+  name: opentransit-state-api
 spec:
   selector:
     matchLabels:
-      run: tryn-api
+      run: opentransit-state-api
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -16,16 +16,18 @@ spec:
   template:
     metadata:
       labels:
-        run: tryn-api
+        run: opentransit-state-api
     spec:
       containers:
-      - image: gcr.io/poetic-genius-233804/tryn-api:latest
+      - image: gcr.io/YOUR_GCP_PROJECT_ID/opentransit-state-api:latest
         imagePullPolicy: IfNotPresent
-        name: tryn-api
+        name: opentransit-state-api
         resources:
           requests:
             cpu: 0.03
         env:
+          - name: OPENTRANSIT_S3_BUCKET
+            value: YOUR_OPENTRANSIT_S3_BUCKET
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:

--- a/kubernetes/state-api-service.yaml
+++ b/kubernetes/state-api-service.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    run: tryn-api
-  name: tryn-api
+    run: opentransit-state-api
+  name: opentransit-state-api
 spec:
   ports:
   - protocol: "TCP"
     port: 80
     targetPort: 4000
   selector:
-    run: tryn-api
+    run: opentransit-state-api
   type: LoadBalancer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "trynmaps-backend",
+  "name": "opentransit-state-api",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tryn-api",
+  "name": "opentransit-state-api",
   "version": "1.0.0",
   "description": "API for historical transit vehicle location data",
   "private": true,
@@ -9,13 +9,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trynmaps/tryn-api.git"
+    "url": "git+https://github.com/codeforpdx/opentransit-state-api.git"
   },
   "author": "Eddy",
   "bugs": {
-    "url": "https://github.com/trynmaps/tryn-api/issues"
+    "url": "https://github.com/codeforpdx/opentransit-state-api/issues"
   },
-  "homepage": "https://github.com/trynmaps/tryn-api#readme",
+  "homepage": "https://github.com/codeforpdx/opentransit-state-api",
   "dependencies": {
     "@creditkarma/graphql-loader": "^0.6.6",
     "@turf/turf": "^5.1.6",

--- a/src/helpers/s3Helper.js
+++ b/src/helpers/s3Helper.js
@@ -4,7 +4,10 @@ var zlib = require('zlib');
 
 const s3 = new AWS.S3();
 
-const s3Bucket = process.env.TRYNAPI_S3_BUCKET || "orion-vehicles";
+const s3Bucket = process.env.OPENTRANSIT_S3_BUCKET;
+if (!s3Bucket) {
+  throw new Error("Missing OPENTRANSIT_S3_BUCKET environment variable");
+}
 console.log(`Reading state from s3://${s3Bucket}`);
 
 /*
@@ -123,4 +126,3 @@ function insertTimestamp(timestamp, vehicles) {
 module.exports = {
   getVehicles,
 };
-


### PR DESCRIPTION
This repository was renamed from tryn-api to opentransit-state-api to make its purpose clearer and to move towards a consistent naming convention for the different OpenTransit repos. This PR updates the "tryn-api" and "orion" references in the documentation, configuration, and code to opentransit-state-api and opentransit-collector, respectively. The S3 bucket is now specified by the environment variable OPENTRANSIT_S3_BUCKET. Any existing users would need to change their local configuration accordingly.

