### PR TITLE
Update S3 key format; fetch list of S3 keys in 1 hour chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "aws-sdk": "^2.334.0",
     "axios": "^0.18.1",
     "cors": "^2.8.4",
+    "luxon": "^2.3.0",
     "express": "~4.15.5",
     "express-graphql": "^0.9.0",
     "lodash": "^4.17.13",


### PR DESCRIPTION
This PR updates opentransit-state-api to match the S3 key format implemented in https://github.com/codeforpdx/opentransit-collector/pull/4 . It also fetches the S3 keys in chunks of 1 hour instead of 1 minute to reduce the number of S3 API calls. 

This PR also includes the error handling code previously implemented in https://github.com/codeforpdx/opentransit-state-api/pull/1 , rebased on to the branch after renaming tryn-api to opentransit-state-api.